### PR TITLE
Implement filter for metrics-definitions list command

### DIFF
--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_util.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/_util.py
@@ -10,9 +10,12 @@ from azure.cli.core.commands.arm import cli_generic_update_command
 
 # COMMANDS UTILITIES
 
-def create_service_adapter(service_model, service_class):
+def create_service_adapter(service_model, service_class=None):
     def _service_adapter(method_name):
-        return '{}#{}.{}'.format(service_model, service_class, method_name)
+        if service_class is not None:
+            return '{}#{}.{}'.format(service_model, service_class, method_name)
+        else:
+            return '{}#{}'.format(service_model, method_name)
 
     return _service_adapter
 

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/commands.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/commands.py
@@ -103,12 +103,12 @@ with ServiceGroup(__name__, get_monitor_tenant_activity_logs_operation,
         c.command('list', 'list')
 
 metric_definitions_operations = create_service_adapter(
-    'azure.monitor.operations.metric_definitions_operations', 'MetricDefinitionsOperations')
+    'azure.cli.command_modules.monitor.custom')
 
 with ServiceGroup(__name__, get_monitor_metric_definitions_operation,
                   metric_definitions_operations) as s:
     with s.group('monitor metric-definitions') as c:
-        c.command('list', 'list')
+        c.command('list', 'list_metric_definitions')
 
 metrics_operations = create_service_adapter(
     'azure.monitor.operations.metrics_operations', 'MetricsOperations')

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/custom.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/custom.py
@@ -19,10 +19,6 @@ def _list_metric_definitions_filter_builder(metric_names=None):
     '''
     filters = []
     if metric_names:
-        if "," in metric_names:
-            names = metric_names.split(",")
-            for metric_name in names:
-                filters.append("name.value eq '{}'".format(metric_name))
-        else:
-            filters.append("name.value eq '{}'".format(metric_names))
+        for metric_name in metric_names:
+            filters.append("name.value eq '{}'".format(metric_name))
     return ' or '.join(filters)

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/custom.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/custom.py
@@ -2,3 +2,27 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
+
+
+def list_metric_definitions(client, resource_uri, metric_names=None):
+    '''Commands to manage metric definitions.
+    :param str resource_uri: The identifier of the resource
+    :param str metric_names: The list of metric names
+    '''
+    odata_filter = _list_metric_definitions_filter_builder(metric_names)
+    metric_definitions = client.list(resource_uri, filter=odata_filter)
+    return list(metric_definitions)
+
+
+def _list_metric_definitions_filter_builder(metric_names=None):
+    '''Build up OData filter string from metric_names
+    '''
+    filters = []
+    if metric_names:
+        if "," in metric_names:
+            names = metric_names.split(",")
+            for metric_name in names:
+                filters.append("name.value eq '{}'".format(metric_name))
+        else:
+            filters.append("name.value eq '{}'".format(metric_names))
+    return ' or '.join(filters)

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/params.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/params.py
@@ -45,3 +45,6 @@ with ParametersContext(command='monitor autoscale-settings create') as c:
         (AutoscaleSettingResource)
 
     c.expand('parameters', AutoscaleSettingResource)
+
+with ParametersContext(command='monitor metric-definitions list') as c:
+    c.argument('metric_names', None, nargs='+')


### PR DESCRIPTION
**Before:**
```
(env) D:\Repos\azure-cli>az monitor metric-definitions list -h

Command
    az monitor metric-definitions list: Lists the metric definitions for the resource.
        The **$filter** parameter is optional, and can be used to only retrieve certain metric
        definitions. For example, get just the definition for the CPU percentage counter:
        $filter=name.value eq '\Processor(_Total)\% Processor Time'. This $filter is very restricted
        and allows only these 'name eq <value>' clauses separated by or operators. No other syntax
        is allowed.

Arguments
    --resource-uri [Required]: The identifier of the resource.
    --filter                 : Reduces the set of data collected. The syntax allowed depends on the
                               operation. See the operation's description for details.

Global Arguments
    --debug                  : Increase logging verbosity to show all debug logs.
    --help -h                : Show this help message and exit.
    --output -o              : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                               json.
    --query                  : JMESPath query string. See http://jmespath.org/ for more information
                               and examples.
    --verbose                : Increase logging verbosity. Use --debug for full debug logs.
```

**After:**
```
(env) vishrut@mac azure-cli (implement-filter-metric-definitions) $ az monitor metric-definitions list -h

Command
    az monitor metric-definitions list: Commands to manage metric definitions.

Arguments
    --resource-uri [Required]: The identifier of the resource.
    --metric-names           : The list of metric names.

Global Arguments
    --debug                  : Increase logging verbosity to show all debug logs.
    --help -h                : Show this help message and exit.
    --output -o              : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                               json.
    --query                  : JMESPath query string. See http://jmespath.org/ for more information
                               and examples.
    --verbose                : Increase logging verbosity. Use --debug for full debug logs.
```

**Example 1:**
```
(env) vishrut@visshamac azure-cli (implement-filter-metric-definitions) $ az monitor metric-definitions list --resource-uri '/subscriptions/xxxxx-xxx-xxx-xxx-xxx/resourceGroups/vishrutrg/providers/Microsoft.Web/sites/vishrutwebapp'
[
  {
    "id": "/subscriptions/xxxxx-xxx-xxx-xxx-xxx/resourceGroups/vishrutrg/providers/Microsoft.Web/sites/vishrutwebapp/providers/microsoft.insights/metricdefinitions/CpuTime",
    "metricAvailabilities": [
      {
        "retention": "30 days, 0:00:00",
        "timeGrain": "0:01:00"
      },
      {
        "retention": "30 days, 0:00:00",
        "timeGrain": "1:00:00"
      }
    ],
    "name": {
      "localizedValue": "CPU Time",
      "value": "CpuTime"
    },
    "primaryAggregationType": "Total",
    "resourceGroup": "vishrutrg",
    "resourceId": "/subscriptions/xxxxx-xxx-xxx-xxx-xxx/resourceGroups/vishrutrg/providers/Microsoft.Web/sites/vishrutwebapp",
    "unit": "Seconds"
  },
  {
    "id": "/subscriptions/xxxxx-xxx-xxx-xxx-xxx/resourceGroups/vishrutrg/providers/Microsoft.Web/sites/vishrutwebapp/providers/microsoft.insights/metricdefinitions/Requests",
    "metricAvailabilities": [
      {
        "retention": "30 days, 0:00:00",
        "timeGrain": "0:01:00"
      },
      {
        "retention": "30 days, 0:00:00",
        "timeGrain": "1:00:00"
      }
    ],
    "name": {
      "localizedValue": "Requests",
      "value": "Requests"
    },
    "primaryAggregationType": "Total",
    "resourceGroup": "vishrutrg",
    "resourceId": "/subscriptions/xxxxx-xxx-xxx-xxx-xxx/resourceGroups/vishrutrg/providers/Microsoft.Web/sites/vishrutwebapp",
    "unit": "Count"
  },
  {
    "id": "/subscriptions/xxxxx-xxx-xxx-xxx-xxx/resourceGroups/vishrutrg/providers/Microsoft.Web/sites/vishrutwebapp/providers/microsoft.insights/metricdefinitions/BytesReceived",
    "metricAvailabilities": [
      {
        "retention": "30 days, 0:00:00",
        "timeGrain": "0:01:00"
      },
      {
        "retention": "30 days, 0:00:00",
        "timeGrain": "1:00:00"
      }
    ],
    "name": {
      "localizedValue": "Data In",
      "value": "BytesReceived"
    },
    "primaryAggregationType": "Total",
    "resourceGroup": "vishrutrg",
    "resourceId": "/subscriptions/xxxxx-xxx-xxx-xxx-xxx/resourceGroups/vishrutrg/providers/Microsoft.Web/sites/vishrutwebapp",
    "unit": "Bytes"
  },
  . . .
```

**Example 2:**
```
(env) vishrut@visshamac azure-cli (implement-filter-metric-definitions) $ az monitor metric-definitions list --resource-uri '/subscriptions/xxxxx-xxx-xxx-xxx-xxx/resourceGroups/vishrutrg/providers/Microsoft.Web/sites/vishrutwebapp' --metric-names "AverageResponseTime,AverageMemoryWorkingSet"
[
  {
    "id": "/subscriptions/xxxxx-xxx-xxx-xxx-xxx/resourceGroups/vishrutrg/providers/Microsoft.Web/sites/vishrutwebapp/providers/microsoft.insights/metricdefinitions/AverageMemoryWorkingSet",
    "metricAvailabilities": [
      {
        "retention": "30 days, 0:00:00",
        "timeGrain": "0:01:00"
      },
      {
        "retention": "30 days, 0:00:00",
        "timeGrain": "1:00:00"
      }
    ],
    "name": {
      "localizedValue": "Average memory working set",
      "value": "AverageMemoryWorkingSet"
    },
    "primaryAggregationType": "Average",
    "resourceGroup": "vishrutrg",
    "resourceId": "/subscriptions/xxxxx-xxx-xxx-xxx-xxx/resourceGroups/vishrutrg/providers/Microsoft.Web/sites/vishrutwebapp",
    "unit": "Bytes"
  },
  {
    "id": "/subscriptions/xxxxx-xxx-xxx-xxx-xxx/resourceGroups/vishrutrg/providers/Microsoft.Web/sites/vishrutwebapp/providers/microsoft.insights/metricdefinitions/AverageResponseTime",
    "metricAvailabilities": [
      {
        "retention": "30 days, 0:00:00",
        "timeGrain": "0:01:00"
      },
      {
        "retention": "30 days, 0:00:00",
        "timeGrain": "1:00:00"
      }
    ],
    "name": {
      "localizedValue": "Average Response Time",
      "value": "AverageResponseTime"
    },
    "primaryAggregationType": "Average",
    "resourceGroup": "vishrutrg",
    "resourceId": "/subscriptions/xxxxx-xxx-xxx-xxx-xxx/resourceGroups/vishrutrg/providers/Microsoft.Web/sites/vishrutwebapp",
    "unit": "Seconds"
  }
]
```

**XPlat CLI Reference**: https://github.com/Azure/azure-xplat-cli/blob/dev/lib/commands/arm/insights/insights.utils.js#L64

@troydai @tjprescott @derekbekoe Please review the PR when you get a chance. Thanks! 