### PR TITLE
Implement filter metrics list command

### DIFF
--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/commands.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/commands.py
@@ -111,8 +111,8 @@ with ServiceGroup(__name__, get_monitor_metric_definitions_operation,
         c.command('list', 'list_metric_definitions')
 
 metrics_operations = create_service_adapter(
-    'azure.monitor.operations.metrics_operations', 'MetricsOperations')
+    'azure.cli.command_modules.monitor.custom')
 
 with ServiceGroup(__name__, get_monitor_metrics_operation, metrics_operations) as s:
     with s.group('monitor metrics') as c:
-        c.command('list', 'list')
+        c.command('list', 'list_metrics')

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/custom.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/custom.py
@@ -38,15 +38,14 @@ def list_metrics(client, resource_uri, time_grain,
     '''Lists the metric values for a resource.
     :param str resource_uri: The identifier of the resource
     :param str time_grain: The time grain. Granularity of the metric data returned in ISO 8601
-                           duration format, eg "duration'PT1M'"
+                           duration format, eg "PT1M"
     :param str start_time: The start time of the query. In ISO format with explicit indication of
                            timezone: 1970-01-01T00:00:00Z, 1970-01-01T00:00:00-0500
     :param str end_time: The end time of the query. In ISO format with explicit indication of
                          timezone: 1970-01-01T00:00:00Z, 1970-01-01T00:00:00-0500
-    :param str metric_names: The list of metric names
+    :param str metric_names: The space separated list of metric names
     '''
     odata_filter = _metrics_odata_filter_builder(time_grain, start_time, end_time, metric_names)
-    print(odata_filter)
     metrics = client.list(resource_uri, filter=odata_filter)
     return list(metrics)
 

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/custom.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/custom.py
@@ -2,6 +2,15 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
+from __future__ import print_function
+import datetime
+
+
+# 1 hour in milliseconds
+DEFAULT_QUERY_TIME_RANGE = 3600000
+
+# ISO format with explicit indication of timezone
+DATE_TIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
 
 def list_metric_definitions(client, resource_uri, metric_names=None):
@@ -9,12 +18,12 @@ def list_metric_definitions(client, resource_uri, metric_names=None):
     :param str resource_uri: The identifier of the resource
     :param str metric_names: The list of metric names
     '''
-    odata_filter = _list_metric_definitions_filter_builder(metric_names)
+    odata_filter = _metric_names_filter_builder(metric_names)
     metric_definitions = client.list(resource_uri, filter=odata_filter)
     return list(metric_definitions)
 
 
-def _list_metric_definitions_filter_builder(metric_names=None):
+def _metric_names_filter_builder(metric_names=None):
     '''Build up OData filter string from metric_names
     '''
     filters = []
@@ -22,3 +31,70 @@ def _list_metric_definitions_filter_builder(metric_names=None):
         for metric_name in metric_names:
             filters.append("name.value eq '{}'".format(metric_name))
     return ' or '.join(filters)
+
+
+def list_metrics(client, resource_uri, time_grain,
+                 start_time=None, end_time=None, metric_names=None):
+    '''Lists the metric values for a resource.
+    :param str resource_uri: The identifier of the resource
+    :param str time_grain: The time grain. Granularity of the metric data returned in ISO 8601
+                           duration format, eg "duration'PT1M'"
+    :param str start_time: The start time of the query. In ISO format with explicit indication of
+                           timezone: 1970-01-01T00:00:00Z, 1970-01-01T00:00:00-0500
+    :param str end_time: The end time of the query. In ISO format with explicit indication of
+                         timezone: 1970-01-01T00:00:00Z, 1970-01-01T00:00:00-0500
+    :param str metric_names: The list of metric names
+    '''
+    odata_filter = _metrics_odata_filter_builder(time_grain, start_time, end_time, metric_names)
+    print(odata_filter)
+    metrics = client.list(resource_uri, filter=odata_filter)
+    return list(metrics)
+
+
+def _metrics_odata_filter_builder(time_grain, start_time=None, end_time=None,
+                                  metric_names=None):
+    '''Build up OData filter string
+    '''
+    filters = []
+    metrics_filter = _metric_names_filter_builder(metric_names)
+    if metrics_filter:
+        filters.append('({})'.format(metrics_filter))
+
+    if time_grain:
+        filters.append("timeGrain eq duration'{}'".format(time_grain))
+
+    filters.append(_validate_time_range_and_add_defaults(start_time, end_time))
+    return ' and '.join(filters)
+
+
+def _validate_time_range_and_add_defaults(start_time, end_time):
+    end_time = _validate_end_time(end_time)
+    start_time = _validate_start_time(start_time, end_time)
+    time_range = "startTime eq {} and endTime eq {}".format(
+        start_time.strftime('%Y-%m-%dT%H:%M:%SZ'),
+        end_time.strftime('%Y-%m-%dT%H:%M:%SZ'))
+    return time_range
+
+
+def _validate_end_time(end_time):
+    result_time = datetime.datetime.utcnow()
+    if isinstance(end_time, str):
+        result_time = datetime.datetime.strptime(end_time, DATE_TIME_FORMAT)
+    return result_time
+
+
+def _validate_start_time(start_time, end_time):
+    if not isinstance(end_time, datetime.datetime):
+        raise ValueError("Input '{}' is not valid datetime. Valid example: 2000-12-31T12:59:59Z"
+                         .format(end_time))
+
+    result_time = end_time - datetime.timedelta(seconds=DEFAULT_QUERY_TIME_RANGE)
+
+    if isinstance(start_time, str):
+        result_time = datetime.datetime.strptime(start_time, DATE_TIME_FORMAT)
+
+    now = datetime.datetime.utcnow()
+    if result_time > now:
+        raise ValueError("start_time '{}' is later than Now {}.".format(start_time, now))
+
+    return result_time

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/params.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/params.py
@@ -47,7 +47,7 @@ with ParametersContext(command='monitor autoscale-settings create') as c:
     c.expand('parameters', AutoscaleSettingResource)
 
 with ParametersContext(command='monitor metric-definitions list') as c:
-    c.argument('metric_names', None, nargs='+')
+    c.argument('metric_names', nargs='+')
 
 with ParametersContext(command='monitor metrics list') as c:
-    c.argument('metric_names', None, nargs='+')
+    c.argument('metric_names', nargs='+')

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/params.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/params.py
@@ -48,3 +48,6 @@ with ParametersContext(command='monitor autoscale-settings create') as c:
 
 with ParametersContext(command='monitor metric-definitions list') as c:
     c.argument('metric_names', None, nargs='+')
+
+with ParametersContext(command='monitor metrics list') as c:
+    c.argument('metric_names', None, nargs='+')


### PR DESCRIPTION
**Before:**
```
(env) D:\Repos\azure-cli>az monitor metrics list -h

Command
    az monitor metrics list: **Lists the metric values for a resource**.
        <br>The **$filter** is used to reduce the set of metric data returned. Some common
        properties for this expression will be: name.value, aggregationType, startTime, endTime,
        timeGrain. The filter expression uses these properties with comparison operators (eg. eq,
        gt, lt) and multiple expressions can be combined with parentheses and 'and/or'
        operators.<br>Some example filter expressions are:<br>- $filter=(name.value eq
        'RunsSucceeded') and aggregationType eq 'Total' and startTime eq 2016-02-20 and endTime eq
        2016-02-21 and timeGrain eq duration'PT1M',<br>- $filter=(name.value eq 'RunsSucceeded') and
        (aggregationType eq 'Total' or aggregationType eq 'Average') and startTime eq 2016-02-20 and
        endTime eq 2016-02-21 and timeGrain eq duration'PT1H',<br>- $filter=(name.value eq
        'ActionsCompleted' or name.value eq 'RunsSucceeded') and (aggregationType eq 'Total' or
        aggregationType eq 'Average') and startTime eq 2016-02-20 and endTime eq 2016-02-21 and
        timeGrain eq duration'PT1M'.<br><br> >**NOTE**: When a metrics query comes in with multiple
        metrics, but with no aggregation types defined, the service will pick the Primary
        aggregation type of the first metrics to be used as the default aggregation type for all the
        metrics.

Arguments
    --resource-uri [Required]: The identifier of the resource.
    --filter                 : Reduces the set of data collected. The syntax allowed depends on the
                               operation. See the operation's description for details.

Global Arguments
    --debug                  : Increase logging verbosity to show all debug logs.
    --help -h                : Show this help message and exit.
    --output -o              : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                               json.
    --query                  : JMESPath query string. See http://jmespath.org/ for more information
                               and examples.
    --verbose                : Increase logging verbosity. Use --debug for full debug logs.
```

**After:**
```
(env) vishrut@visshamac azure-cli (implement-filter-metrics) $ az monitor metrics list -h

Command
    az monitor metrics list: Lists the metric values for a resource.

Arguments
    --resource-uri [Required]: The identifier of the resource.
    --time-grain   [Required]: The time grain. Granularity of the metric data returned in ISO 8601
                               duration format, eg "duration'PT1M'".
    --end-time               : The end time of the query. In ISO format with explicit indication of
                               timezone: 1970-01-01T00:00:00Z, 1970-01-01T00:00:00-0500.
    --metric-names           : The list of metric names.
    --start-time             : The start time of the query. In ISO format with explicit indication
                               of timezone: 1970-01-01T00:00:00Z, 1970-01-01T00:00:00-0500.

Global Arguments
    --debug                  : Increase logging verbosity to show all debug logs.
    --help -h                : Show this help message and exit.
    --output -o              : Output format.  Allowed values: json, jsonc, table, tsv.  Default:
                               json.
    --query                  : JMESPath query string. See http://jmespath.org/ for more information
                               and examples.
    --verbose                : Increase logging verbosity. Use --debug for full debug logs.
```

**Example 1:**
```
az monitor metrics list --resource-uri '/subscriptions/xxxxx-xxx-xxx-xxx-xxx/resourceGroups/vishrutrg/providers/Microsoft.Web/sites/vishrutwebapp' --metric-names AverageResponseTime AverageMemoryWorkingSet --time-grain PT1M
```

**Example 2:**
```
az monitor metrics list --resource-uri '/subscriptions/xxxxx-xxx-xxx-xxx-xxx/resourceGroups/vishrutrg/providers/Microsoft.Web/sites/vishrutwebapp' --time-grain PT1M --metric-names AverageMemoryWorkingSet --start-time  2017-01-11T12:59:59Z --end-time 2017-01-30T12:59:59Z
```

**XPlat CLI Reference**: https://github.com/Azure/azure-xplat-cli/blob/dev/lib/commands/arm/insights/insights.metrics._js#L44

@troydai @tjprescott @derekbekoe Please review the PR when you get a chance. Thanks! 