### PR TITLE
Adding scaffold command in autoscale-settings

### DIFF
--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/autoscale-parameters-template.json
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/autoscale-parameters-template.json
@@ -1,0 +1,38 @@
+{
+  "autoscale_setting_resource_name": "autoscale setting resource name",
+  "location": "West US",
+  "tags": {},
+  "profiles": [
+    {
+      "name": "name of the profile",
+      "capacity": {
+        "minimum": "1",
+        "maximum": "5",
+        "default": "3"
+      },
+      "rules": [
+        {
+          "metric_trigger": {
+            "metric_name": "name of the metric",
+            "metric_resource_uri": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerName}/{resourceName}/{subResourceName}",
+            "time_grain": "(duration in ISO8601 format)PT5M",
+            "statistic": "Average or Min or Max or Sum",
+            "time_window": "(duration in ISO8601 format)PT45M",
+            "time_aggregation": "Average or Minimum or Maximum or Total or Count",
+            "operator": "Equals or NotEquals or GreaterThan or GreaterThanOrEqual or LessThan or LessThanOrEquals",
+            "threshold": 100
+          },
+          "scale_action": {
+            "direction": "None or Increase or Decrease",
+            "type": "ChangeCount or PercentChangeCount or ExactCount",
+            "value": "2 (number of instances that are involved in the scaling)",
+            "cooldown": "(duration in ISO8601 format)PT20M"
+          }
+        }
+      ]
+    }
+  ],
+  "notifications": [],
+  "enabled": false,
+  "target_resource_uri": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerName}/{resourceName}/{subResourceName}"
+}

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/autoscale-parameters-template.json
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/autoscale-parameters-template.json
@@ -1,10 +1,10 @@
 {
-  "autoscale_setting_resource_name": "autoscale setting resource name",
+  "autoscale_setting_resource_name": "{MyAutoscaleSettings}",
   "location": "West US",
   "tags": {},
   "profiles": [
     {
-      "name": "name of the profile",
+      "name": "{AutoscaleProfile}",
       "capacity": {
         "minimum": "1",
         "maximum": "5",
@@ -13,18 +13,18 @@
       "rules": [
         {
           "metric_trigger": {
-            "metric_name": "name of the metric",
-            "metric_resource_uri": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerName}/{resourceName}/{subResourceName}",
+            "metric_name": "{name}",
+            "metric_resource_uri": "{FullyQualifiedAzureResourceID}",
             "time_grain": "(duration in ISO8601 format)PT5M",
-            "statistic": "Average or Min or Max or Sum",
+            "statistic": "{Average|Min|Max|Sum}",
             "time_window": "(duration in ISO8601 format)PT45M",
-            "time_aggregation": "Average or Minimum or Maximum or Total or Count",
-            "operator": "Equals or NotEquals or GreaterThan or GreaterThanOrEqual or LessThan or LessThanOrEquals",
+            "time_aggregation": "{Average|Minimum|Maximum|Total|Count}",
+            "operator": "{Equals|NotEquals|GreaterThan|GreaterThanOrEqual|LessThan|LessThanOrEquals}",
             "threshold": 100
           },
           "scale_action": {
-            "direction": "None or Increase or Decrease",
-            "type": "ChangeCount or PercentChangeCount or ExactCount",
+            "direction": "{None|Increase|Decrease}",
+            "type": "{ChangeCount|PercentChangeCount|ExactCount}",
             "value": "2 (number of instances that are involved in the scaling)",
             "cooldown": "(duration in ISO8601 format)PT20M"
           }
@@ -34,5 +34,5 @@
   ],
   "notifications": [],
   "enabled": false,
-  "target_resource_uri": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{providerName}/{resourceName}/{subResourceName}"
+  "target_resource_uri": "{FullyQualifiedAzureResourceID}"
 }

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/commands.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/commands.py
@@ -76,6 +76,14 @@ with ServiceGroup(__name__, get_monitor_autoscale_settings_operation,
         c.command('list', 'list_by_resource_group')
         c.generic_update_command('update', 'get', 'create_or_update')
 
+autoscale_settings_scaffold = create_service_adapter(
+    'azure.cli.command_modules.monitor.custom')
+
+with ServiceGroup(__name__, get_monitor_autoscale_settings_operation,
+                  autoscale_settings_scaffold) as s:
+    with s.group('monitor autoscale-settings') as c:
+        c.command('scaffold', 'scaffold_autoscale_settings_parameters')
+
 
 # DATA COMMANDS
 event_categories_operations = create_service_adapter(

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/commands.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/commands.py
@@ -82,7 +82,7 @@ autoscale_settings_scaffold = create_service_adapter(
 with ServiceGroup(__name__, get_monitor_autoscale_settings_operation,
                   autoscale_settings_scaffold) as s:
     with s.group('monitor autoscale-settings') as c:
-        c.command('scaffold', 'scaffold_autoscale_settings_parameters')
+        c.command('get-parameters-template', 'scaffold_autoscale_settings_parameters')
 
 
 # DATA COMMANDS

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/custom.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/custom.py
@@ -4,7 +4,9 @@
 # --------------------------------------------------------------------------------------------
 from __future__ import print_function
 import datetime
-from azure.cli.core._util import CLIError
+import json
+import os
+from azure.cli.core._util import get_file_json, CLIError
 
 
 # 1 hour in milliseconds
@@ -13,6 +15,10 @@ DEFAULT_QUERY_TIME_RANGE = 3600000
 # ISO format with explicit indication of timezone
 DATE_TIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
+# Autoscale settings parameter scaffold file path
+CURR_DIR = os.path.dirname(os.path.realpath(__file__))
+AUTOSCALE_SETTINGS_PARAMETER_FILE_PATH = os.path.join(CURR_DIR,
+                                                      'autoscale-parameters-template.json')
 
 def list_metric_definitions(client, resource_id, metric_names=None):
     '''Commands to manage metric definitions.
@@ -34,6 +40,7 @@ def _metric_names_filter_builder(metric_names=None):
     return ' or '.join(filters)
 
 
+# pylint: disable=too-many-arguments
 def list_metrics(client, resource_id, time_grain,
                  start_time=None, end_time=None, metric_names=None):
     '''Lists the metric values for a resource.
@@ -100,6 +107,7 @@ def _validate_start_time(start_time, end_time):
     return result_time
 
 
+# pylint: disable=too-many-arguments
 def list_activity_logs(client, correlation_id=None, resource_group=None, resource_id=None,
                        resource_provider=None, start_time=None, end_time=None,
                        caller=None, status=None, max_events=50, select=None):
@@ -134,6 +142,7 @@ def list_activity_logs(client, correlation_id=None, resource_group=None, resourc
     return _limit_results(activity_logs, max_events)
 
 
+# pylint: disable=too-many-arguments
 def _build_activity_logs_odata_filter(correlation_id=None, resource_group=None, resource_id=None,
                                       resource_provider=None, start_time=None, end_time=None,
                                       caller=None, status=None):
@@ -205,3 +214,16 @@ def _limit_results(paged, limit):
         else:
             break
     return list(results)
+
+
+def scaffold_autoscale_settings_parameters(client):  # pylint: disable=unused-argument
+    '''Scaffold fully formed autoscale-settings' parameters as json template
+    '''
+    return _load_autoscale_settings_prameres(AUTOSCALE_SETTINGS_PARAMETER_FILE_PATH)
+
+
+def _load_autoscale_settings_prameres(file_path):
+    if not os.path.exists(file_path):
+        raise CLIError('File {} not found.'.format(file_path))
+
+    return get_file_json(file_path)

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/custom.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/custom.py
@@ -4,7 +4,6 @@
 # --------------------------------------------------------------------------------------------
 from __future__ import print_function
 import datetime
-import json
 import os
 from azure.cli.core._util import get_file_json, CLIError
 
@@ -15,10 +14,6 @@ DEFAULT_QUERY_TIME_RANGE = 3600000
 # ISO format with explicit indication of timezone
 DATE_TIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
-# Autoscale settings parameter scaffold file path
-CURR_DIR = os.path.dirname(os.path.realpath(__file__))
-AUTOSCALE_SETTINGS_PARAMETER_FILE_PATH = os.path.join(CURR_DIR,
-                                                      'autoscale-parameters-template.json')
 
 def list_metric_definitions(client, resource_id, metric_names=None):
     '''Commands to manage metric definitions.
@@ -219,10 +214,15 @@ def _limit_results(paged, limit):
 def scaffold_autoscale_settings_parameters(client):  # pylint: disable=unused-argument
     '''Scaffold fully formed autoscale-settings' parameters as json template
     '''
-    return _load_autoscale_settings_prameres(AUTOSCALE_SETTINGS_PARAMETER_FILE_PATH)
+    # Autoscale settings parameter scaffold file path
+    curr_dir = os.path.dirname(os.path.realpath(__file__))
+    autoscale_settings_parameter_file_path = os.path.join(
+        curr_dir, 'autoscale-parameters-template.json')
+
+    return _load_autoscale_settings_parameters(autoscale_settings_parameter_file_path)
 
 
-def _load_autoscale_settings_prameres(file_path):
+def _load_autoscale_settings_parameters(file_path):
     if not os.path.exists(file_path):
         raise CLIError('File {} not found.'.format(file_path))
 

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/params.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/params.py
@@ -41,10 +41,10 @@ with ParametersContext(command='monitor log-profiles create') as c:
     c.expand('parameters', LogProfileProperties)
 
 with ParametersContext(command='monitor autoscale-settings create') as c:
-    from azure.mgmt.monitor.models.autoscale_setting_resource import \
-        (AutoscaleSettingResource)
-
-    c.expand('parameters', AutoscaleSettingResource)
+    c.register('parameters', ('--parameters',),
+               type=json.loads,
+               help='JSON encoded parameters configuration. Use @{file} to load from a file.'
+                    'Use az autoscale-settings scaffold to export parameters json template.')
 
 with ParametersContext(command='monitor metric-definitions list') as c:
     c.argument('metric_names', nargs='+')

--- a/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/params.py
+++ b/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/params.py
@@ -44,7 +44,7 @@ with ParametersContext(command='monitor autoscale-settings create') as c:
     c.register('parameters', ('--parameters',),
                type=json.loads,
                help='JSON encoded parameters configuration. Use @{file} to load from a file.'
-                    'Use az autoscale-settings scaffold to export parameters json template.')
+                    'Use az autoscale-settings get-parameters-template to export json template.')
 
 with ParametersContext(command='monitor metric-definitions list') as c:
     c.argument('metric_names', nargs='+')


### PR DESCRIPTION
**Help**
```
(env) vishrut@mac azure-cli (simplify-autoscale-create) $ az monitor autoscale-settings -h

Group
    az monitor autoscale-settings: Commands to manage autoscale settings.

Commands:
    create  : Creates or updates an autoscale setting.
    delete  : Deletes and autoscale setting.
    list    : Lists the autoscale settings for a resource group.
    scaffold: Scaffold fully formed autoscale-settings parameters structure template.
    show    : Gets an autoscale setting.
    update  : Updates an autoscale setting.
```

**Get Scaffold json template to be filled-in:**
```
(env) vishrut@mac azure-cli (simplify-autoscale-create) $ az monitor autoscale-settings scaffold

{
  "autoscale_setting_resource_name": "{MyAutoscaleSettings}",
  "enabled": false,
  "location": "West US",
  "notifications": [],
  "profiles": [
    {
      "capacity": {
        "default": "3",
        "maximum": "5",
        "minimum": "1"
      },
      "name": "{AutoscaleProfile}",
      "rules": [
        {
          "metric_trigger": {
            "metric_name": "{name}",
            "metric_resource_uri": "{FullyQualifiedAzureResourceID}",
            "operator": "{Equals|NotEquals|GreaterThan|GreaterThanOrEqual|LessThan|LessThanOrEquals}",
            "statistic": "{Average|Min|Max|Sum}",
            "threshold": 100,
            "time_aggregation": "{Average|Minimum|Maximum|Total|Count}",
            "time_grain": "(duration in ISO8601 format)PT5M",
            "time_window": "(duration in ISO8601 format)PT45M"
          },
          "scale_action": {
            "cooldown": "(duration in ISO8601 format)PT20M",
            "direction": "{None|Increase|Decrease}",
            "type": "{ChangeCount|PercentChangeCount|ExactCount}",
            "value": "2 (number of instances that are involved in the scaling)"
          }
        }
      ]
    }
  ],
  "tags": {},
  "target_resource_uri": "{FullyQualifiedAzureResourceID}"
}

```

**Use json file for creating atuoscale-settings profile**
```
(env) vishrut@mac azure-cli (simplify-autoscale-create) $ az monitor autoscale-settings create -n settings1 --parameters @/Users/vishrut/repos/azure-cli/src/command_modules/azure-cli-monitor/azure/cli/command_modules/monitor/tests/autoscale-settings.json -g scalesetrg3
{
  "autoscaleSettingResourceName": "settings1",
  "enabled": false,
  "id": "/subscriptions/xxxx-xxxx-xxxx/resourceGroups/scalesetrg3/providers/microsoft.insights/autoscalesettings/settings1",
  "location": "West US",
  "name": "settings1",
  "notifications": null,
  "profiles": [
    {
      "capacity": {
        "default": "4",
        "maximum": "5",
        "minimum": "1"
      },
      "fixedDate": null,
      "name": "Day",
      "recurrence": null,
      "rules": [
        {
          "metricTrigger": {
            "metricName": "Percentage CPU",
            "metricResourceUri": "/subscriptions/xxxx-xxxx-xxxx/resourceGroups/scalesetrg3/providers/Microsoft.Compute/virtualMachineScaleSets/vmscaleset3",
            "operator": "GreaterThanOrEqual",
            "statistic": "Average",
            "threshold": 60.0,
            "timeAggregation": "Average",
            "timeGrain": "0:05:00",
            "timeWindow": "0:45:00"
          },
          "scaleAction": {
            "cooldown": "0:20:00",
            "direction": "Increase",
            "type": "ChangeCount",
            "value": "2"
          }
        }
      ]
    }
  ],
  "resourceGroup": "scalesetrg3",
  "tags": {
    "$type": "Microsoft.WindowsAzure.Management.Common.Storage.CasePreservedDictionary, Microsoft.WindowsAzure.Management.Common.Storage"
  },
  "targetResourceUri": "/subscriptions/xxxx-xxxx-xxxx/resourceGroups/scalesetrg3/providers/Microsoft.Compute/virtualMachineScaleSets/vmscaleset3",
  "type": "Microsoft.Insights/autoscaleSettings"
}

```

@troydai @tjprescott @derekbekoe Please review the PR when you get a chance. Thanks! 

Also please advise if the location of the scaffold command or template file doesn't seem appropriate. 